### PR TITLE
Make Paywall notice actually noticable

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -342,7 +342,6 @@ table.highlight-row-on-hover tr:hover td {
 
 .paywall-notice {
     font-style: italic;
-    font-size: 11px;
     width: 100%;
 
     display: flex;
@@ -350,7 +349,6 @@ table.highlight-row-on-hover tr:hover td {
 }
 
 .paywall-notice > div {
-    max-width: 300px;
     text-align: center;
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -139,7 +139,7 @@ const IndexPage = () => {
 
                         {
                             !paywallEnabled &&
-                                <div class="paywall-notice">
+                                <div className="paywall-notice">
                                     <div>
                                         Please note that DeArrow is in beta.{" "}
                                         DeArrow is free, forever, for anyone who installs during the beta. However,{" "}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -138,13 +138,14 @@ const IndexPage = () => {
                         </a>
 
                         {
-                            !paywallEnabled
-                                <h3>DeArrow's Future</h3>
-                                <div>
-                                    Please note that DeArrow is in beta.{" "}
-                                    DeArrow is free, forever, for anyone who installs during the beta. However,{" "}
-                                    there will be a soft-paywall for new users in the future.{" "}
-                                    <a href="https://gist.github.com/ajayyy/36a96ffc786f4e518fb62cac8b9674aa" rel="noreferrer" target="_blank">See details</a>
+                            !paywallEnabled &&
+                                <div class="paywall-notice">
+                                    <div>
+                                        Please note that DeArrow is in beta.{" "}
+                                        DeArrow is free, forever, for anyone who installs during the beta. However,{" "}
+                                        there will be a soft-paywall for new users in the future.<br/>
+                                        <a href="https://gist.github.com/ajayyy/36a96ffc786f4e518fb62cac8b9674aa" rel="noreferrer" target="_blank">See details</a>
+                                    </div>
                                 </div>
                         }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -138,14 +138,13 @@ const IndexPage = () => {
                         </a>
 
                         {
-                            !paywallEnabled &&
-                                <div className="paywall-notice">
-                                    <div>
-                                        Please note that DeArrow is in beta.{" "}
-                                        DeArrow is free, forever, for anyone who installs during the beta. However,{" "}
-                                        there will be a soft-paywall for new users in the future.{" "}
-                                        <a href="https://gist.github.com/ajayyy/36a96ffc786f4e518fb62cac8b9674aa" rel="noreferrer" target="_blank">See details</a>
-                                    </div>
+                            !paywallEnabled
+                                <h3>DeArrow's Future</h3>
+                                <div>
+                                    Please note that DeArrow is in beta.{" "}
+                                    DeArrow is free, forever, for anyone who installs during the beta. However,{" "}
+                                    there will be a soft-paywall for new users in the future.{" "}
+                                    <a href="https://gist.github.com/ajayyy/36a96ffc786f4e518fb62cac8b9674aa" rel="noreferrer" target="_blank">See details</a>
                                 </div>
                         }
 


### PR DESCRIPTION
Having this important piece of text in such a small size is almost ironic to the "I want to keep this as open as possible!" line on the site itself.

If anything is this a very important thing users would like to know. After all is having such a small text after the big download buttons similar to these tiny text companies use to hide exceptions and other stuff behind to then use an asterisk for pointing to it.*
\
\
\
\
\
\
\
\
\
\*just like I did just here...